### PR TITLE
NetworkReady event is now instanciated on constructor

### DIFF
--- a/System.Device.WiFi/NetworkHelper/WiFiNetworkHelper.cs
+++ b/System.Device.WiFi/NetworkHelper/WiFiNetworkHelper.cs
@@ -17,10 +17,10 @@ namespace nanoFramework.Networking
     public static class WiFiNetworkHelper
     {
         private static ManualResetEvent _ipAddressAvailable;
-        private static ManualResetEvent _networkReady;
+        private static ManualResetEvent _networkReady = new(false);
         private static bool _requiresDateTime;
 
-        private static string _ssid;
+        private static st = new(false)ring _ssid;
         private static string _password;
         private static WiFiAdapter _wifi;
         private static WiFiReconnectionKind _reconnectionKind;
@@ -495,9 +495,6 @@ namespace nanoFramework.Networking
 
                     // setup handler
                     NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler(AddressChangedCallback);
-
-                    // instantiate events
-                    _networkReady = new(false);
                 }
 
                 if(!string.IsNullOrEmpty(_ssid) &&
@@ -588,7 +585,7 @@ namespace nanoFramework.Networking
         internal static void ResetInstance()
         {
             _ipAddressAvailable = null;
-            _networkReady = null;
+            _networkReady = new(false);
             _requiresDateTime = false;
             _networkHelperStatus = NetworkHelperStatus.None;
             _helperException = null;

--- a/System.Device.WiFi/NetworkHelper/WiFiNetworkHelper.cs
+++ b/System.Device.WiFi/NetworkHelper/WiFiNetworkHelper.cs
@@ -20,7 +20,7 @@ namespace nanoFramework.Networking
         private static ManualResetEvent _networkReady = new(false);
         private static bool _requiresDateTime;
 
-        private static st = new(false)ring _ssid;
+        private static string _ssid;
         private static string _password;
         private static WiFiAdapter _wifi;
         private static WiFiReconnectionKind _reconnectionKind;


### PR DESCRIPTION
## Description
- NetworkReady event is now instanciated on constructor.
- Update code accordingly.

## Motivation and Context
- Allow waiting for the event before calling the setup methods.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
