### PR TITLE
Fix WiFi helper retry/reset behavior and test API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you need an explicit reconnect with credentials, use `ConnectDhcp()` instead.
 
 When using `SetupNetworkHelper()`, `NetworkReady` is reset when the connection is lost and re-signaled when it is restored, accurately reflecting live network state. Code that previously assumed `NetworkReady` would remain set permanently after first connect should be updated to handle transient disconnects.
 
-## 
+## Feedback and documentation
 
 For documentation, providing feedback, issues and finding out how to contribute please refer to the [Home repo](https://github.com/nanoframework/Home).
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,60 @@ var success = WaitForValidIPAndDate(true, NetworkInterfaceType.Ethernet, cs.Toke
 // if success is true then you are connected
 ```
 
-## Feedback and documentation
+### Retry and reconfiguration
+
+#### Retry after timeout
+
+Token-based methods (`ConnectDhcp`, `ScanAndConnectDhcp`, `ConnectFixAddress`) are retryable. If a connection attempt times out, call the method again:
+
+```csharp
+bool connected = false;
+while (!connected)
+{
+    CancellationTokenSource cs = new(30000);
+    connected = WifiNetworkHelper.ConnectDhcp(Ssid, Password, requiresDateTime: true, token: cs.Token);
+    if (!connected)
+    {
+        Debug.WriteLine($"Not ready, status: {WifiNetworkHelper.Status}");
+        Thread.Sleep(5000);
+    }
+}
+```
+
+#### Switching networks or restarting
+
+To switch to a different SSID or restart the event-based helper, call `Reset()` first:
+
+```csharp
+// Disconnect from current network if needed
+WifiNetworkHelper.Disconnect();
+
+// Reset the helper so it can be reconfigured
+WifiNetworkHelper.Reset();
+
+// Connect to a different SSID
+CancellationTokenSource cs = new(30000);
+WifiNetworkHelper.ConnectDhcp("NewSSID", "NewPassword", token: cs.Token);
+```
+
+The same applies to the event-based `SetupNetworkHelper`:
+
+```csharp
+WifiNetworkHelper.Reset();
+WifiNetworkHelper.SetupNetworkHelper("NewSSID", "NewPassword");
+```
+
+#### `Reconnect()` vs. `ConnectDhcp()`
+
+`Reconnect()` does **not** actively send join credentials. It only waits for the platform's automatic reconnection (configured via `WifiReconnectionKind.Automatic`) to produce a valid IP address. Use it only when credentials are already stored on the device and the platform is expected to reconnect automatically.
+
+If you need an explicit reconnect with credentials, use `ConnectDhcp()` instead.
+
+#### `NetworkReady` behaviour
+
+When using `SetupNetworkHelper()`, `NetworkReady` is reset when the connection is lost and re-signaled when it is restored, accurately reflecting live network state. Code that previously assumed `NetworkReady` would remain set permanently after first connect should be updated to handle transient disconnects.
+
+## 
 
 For documentation, providing feedback, issues and finding out how to contribute please refer to the [Home repo](https://github.com/nanoframework/Home).
 

--- a/System.Device.Wifi/NetworkHelper/WifiNetworkHelper.cs
+++ b/System.Device.Wifi/NetworkHelper/WifiNetworkHelper.cs
@@ -44,7 +44,7 @@ namespace nanoFramework.Networking
         /// The conditions for this are setup in the call to <see cref="WifiNetworkHelper.SetupNetworkHelper"/>. 
         /// It will be a composition of network connected, IpAddress available and valid system <see cref="DateTime"/>.
         /// <para>
-        /// When using <see cref="SetupNetworkHelper()"/>, this event is reset when the connection is lost
+        /// When using <see cref="SetupNetworkHelper(bool)"/>, this event is reset when the connection is lost
         /// and re-signaled when it is restored, accurately reflecting live network state.
         /// </para>
         /// </remarks>
@@ -271,7 +271,7 @@ namespace nanoFramework.Networking
         }
 
         /// <summary>
-        /// Resets the WifiNetworkHelper to its initial state, allowing <see cref="SetupNetworkHelper()"/> to be called again
+        /// Resets the WifiNetworkHelper to its initial state, allowing <see cref="SetupNetworkHelper(bool)"/> to be called again
         /// or the network configuration to be changed.
         /// </summary>
         /// <remarks>
@@ -534,6 +534,45 @@ namespace nanoFramework.Networking
         }
 
         /// <summary>
+        /// Ensures the target Wi-Fi profile is configured and returns whether an explicit connect should be performed.
+        /// </summary>
+        /// <param name="nis">Network interfaces currently available.</param>
+        /// <returns><see langword="true"/> when a connect should be issued after IP setup; otherwise <see langword="false"/>.</returns>
+        private static bool TryPrepareWifiConnection(NetworkInterface[] nis)
+        {
+            if (string.IsNullOrEmpty(_ssid) || string.IsNullOrEmpty(_password))
+            {
+                return false;
+            }
+
+            foreach (NetworkInterface ni in nis)
+            {
+                if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
+                {
+                    Wireless80211Configuration wc = Wireless80211Configuration.GetAllWireless80211Configurations()[ni.SpecificConfigId];
+
+                    if (wc.Ssid == _ssid)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            _wifi.Disconnect();
+
+            foreach (NetworkInterface ni in nis)
+            {
+                if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
+                {
+                    StoreWifiConfiguration(ni);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Perform setup of the various fields and events, along with any of the required event handlers.
         /// </summary>
         /// <param name="setupEvents">Set <see langword="true"/> to setup the events and background thread. Required for the event-based approach. Not required for the CancellationToken approach.</param>
@@ -549,12 +588,8 @@ namespace nanoFramework.Networking
                 // set flag
                 _helperInstanciated = true;
 
-                // flag to connect to Wifi after IP setup
-                bool connectToWifi = false;
-
                 // setup event
                 _ipAddressAvailable = new(false);
-
 
                 // currently we only support one Wifi adapter, so this is it
                 _wifi = WifiAdapter.FindAllAdapters()[0];
@@ -572,57 +607,7 @@ namespace nanoFramework.Networking
                 // setup handler
                 NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler(AddressChangedCallback);
 
-                if (!string.IsNullOrEmpty(_ssid) &&
-                    !string.IsNullOrEmpty(_password))
-                {
-                    bool isAlreadyConnected = false;
-
-                    // this is to connect to a specific Wifi network
-                    // check if device it's already connected to the correct network
-                    foreach (NetworkInterface ni in nis)
-                    {
-                        if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
-                        {
-                            Wireless80211Configuration wc = Wireless80211Configuration.GetAllWireless80211Configurations()[ni.SpecificConfigId];
-
-                            // Let's make sure this configuration is saved
-                            if (wc.Ssid == _ssid)
-                            {
-                                isAlreadyConnected = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!isAlreadyConnected)
-                    {
-                        _wifi.Disconnect();
-                        isAlreadyConnected = false;
-                    }
-
-                    if (!isAlreadyConnected)
-                    {
-                        nis = NetworkInterface.GetAllNetworkInterfaces();
-
-                        foreach (NetworkInterface ni in nis)
-                        {
-                            if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
-                            {
-                                _wifi.Disconnect();
-
-                                // Make sure we store the configuration
-                                StoreWifiConfiguration(ni);
-
-                                // set flag to connect to Wifi after IP config
-                                connectToWifi = true;
-
-                                // done here
-                                break;
-                            }
-                        }
-                    }
-
-                }
+                bool connectToWifi = TryPrepareWifiConnection(nis);
 
                 NetworkHelperInternal.InternalSetupHelper(
                     nis,

--- a/System.Device.Wifi/NetworkHelper/WifiNetworkHelper.cs
+++ b/System.Device.Wifi/NetworkHelper/WifiNetworkHelper.cs
@@ -33,7 +33,7 @@ namespace nanoFramework.Networking
         private static NetworkInterfaceType _workingNetworkInterface = NetworkInterfaceType.Wireless80211;
 
         /// <summary>
-        /// This flag will make sure there is only one and only call to any of the helper methods.
+        /// This flag will make sure there is only one and only one call to the event-based helper methods.
         /// </summary>
         private static bool _helperInstanciated = false;
 
@@ -42,7 +42,12 @@ namespace nanoFramework.Networking
         /// </summary>
         /// <remarks>
         /// The conditions for this are setup in the call to <see cref="WifiNetworkHelper.SetupNetworkHelper"/>. 
-        /// It will be a composition of network connected, IpAddress available and valid system <see cref="DateTime"/>.</remarks>
+        /// It will be a composition of network connected, IpAddress available and valid system <see cref="DateTime"/>.
+        /// <para>
+        /// When using <see cref="SetupNetworkHelper()"/>, this event is reset when the connection is lost
+        /// and re-signaled when it is restored, accurately reflecting live network state.
+        /// </para>
+        /// </remarks>
         public static ManualResetEvent NetworkReady => _networkReady;
 
         /// <summary>
@@ -60,7 +65,7 @@ namespace nanoFramework.Networking
         /// That will be the network connection to be up, having a valid IpAddress and optionally for a valid date and time to become available.
         /// </summary>
         /// <param name="requiresDateTime">Set to <see langword="true"/> if valid date and time are required.</param>
-        /// <exception cref="InvalidOperationException">If any of the <see cref="NetworkHelper"/> methods is called more than once.</exception>
+        /// <exception cref="InvalidOperationException">If called more than once without an intervening call to <see cref="Reset"/>.</exception>
         /// <exception cref="NotSupportedException">There is no network interface configured. Open the 'Edit Network Configuration' in Device Explorer and configure one.</exception>
         public static void SetupNetworkHelper(bool requiresDateTime = false)
         {
@@ -78,6 +83,7 @@ namespace nanoFramework.Networking
         /// </summary>
         /// <param name="ipConfiguration">The static IP configuration you want to apply.</param>
         /// <param name="requiresDateTime">Set to <see langword="true"/> if valid date and time are required.</param>
+        /// <exception cref="InvalidOperationException">If called more than once without an intervening call to <see cref="Reset"/>.</exception>
         /// <exception cref="NotSupportedException">There is no network interface configured. Open the 'Edit Network Configuration' in Device Explorer and configure one.</exception>
         public static void SetupNetworkHelper(
             IPConfiguration ipConfiguration,
@@ -100,7 +106,7 @@ namespace nanoFramework.Networking
         /// <param name="ssid">The SSID of the network you are trying to connect to.</param>
         /// <param name="password">The password associated to the SSID of the network you are trying to connect to.</param>
         /// <param name="reconnectionKind">The <see cref="WifiReconnectionKind"/> to setup for the connection.</param>
-        /// <exception cref="InvalidOperationException">If any of the <see cref="NetworkHelper"/> methods is called more than once.</exception>
+        /// <exception cref="InvalidOperationException">If called more than once without an intervening call to <see cref="Reset"/>.</exception>
         /// <exception cref="NotSupportedException">There is no network interface configured. Open the 'Edit Network Configuration' in Device Explorer and configure one.</exception>
         public static void SetupNetworkHelper(
             string ssid,
@@ -137,6 +143,7 @@ namespace nanoFramework.Networking
         /// <summary>
         /// This method will connect the network with DHCP enabled, for your SSID and try to connect to it with the credentials you've passed. This will save as well
         /// the configuration of your network.
+        /// This method is retryable and can be called multiple times after a previous call times out or fails.
         /// </summary>
         /// <param name="ssid">The SSID of the network you are trying to connect to.</param>
         /// <param name="password">The password associated to the SSID of the network you are trying to connect to.</param>
@@ -165,6 +172,7 @@ namespace nanoFramework.Networking
         /// <summary>
         /// This method will connect the network with the static IP address you are providing, for your SSID and try to connect to it with the credentials you've passed. This will save as well
         /// the configuration of your network.
+        /// This method is retryable and can be called multiple times after a previous call times out or fails.
         /// </summary>
         /// <param name="ssid">The SSID you are trying to connect to.</param>
         /// <param name="password">The password associated to the SSID you are trying to connect to.</param>
@@ -195,6 +203,7 @@ namespace nanoFramework.Networking
         /// <summary>
         /// This method will scan and connect the network with DHCP enabled, for your SSID and try to connect to it with the credentials you've passed. This will save as well
         /// the configuration of your network. 
+        /// This method is retryable and can be called multiple times after a previous call times out or fails.
         /// </summary>
         /// <param name="ssid">The SSID you are trying to connect to.</param>
         /// <param name="password">The password associated to the SSID you are trying to connect to.</param>
@@ -221,15 +230,21 @@ namespace nanoFramework.Networking
                 token);
 
         /// <summary>
-        /// This method will connect the network, the information used to connect is the one already stored on the device.
+        /// Waits for the platform's automatic WiFi reconnection to produce a valid IP address.
+        /// This method does not actively send join credentials to the access point.
+        /// It relies on the <see cref="WifiReconnectionKind.Automatic"/> behaviour previously configured
+        /// when calling <see cref="ConnectDhcp"/> or <see cref="ConnectFixAddress"/>.
         /// </summary>
+        /// <remarks>
+        /// Use this method only when the device credentials are already stored and the platform is expected
+        /// to reconnect automatically. If you need an explicit reconnect with credentials, call
+        /// <see cref="ConnectDhcp"/> or <see cref="ConnectFixAddress"/> instead.
+        /// This method is retryable and can be called multiple times.
+        /// </remarks>
         /// <param name="requiresDateTime">Set to <see langword="true"/> if valid date and time are required.</param>
         /// <param name="wifiAdapterId">The index of the Wifi adapter to be used. Relevant only if there are multiple Wifi adapters.</param>
         /// <param name="token">A <see cref="CancellationToken"/> used for timing out the operation.</param>
         /// <returns><see langword="true"/> on success. On failure returns <see langword="false"/> and details with the cause of the failure are made available in the <see cref="Status"/> property</returns>
-        /// <remarks>
-        /// This function can be called only if an existing network has been setup previously and if the credentials are valid.
-        /// </remarks>
         public static bool Reconnect(
             bool requiresDateTime = false,
             int wifiAdapterId = 0,
@@ -253,6 +268,33 @@ namespace nanoFramework.Networking
 
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Resets the WifiNetworkHelper to its initial state, allowing <see cref="SetupNetworkHelper()"/> to be called again
+        /// or the network configuration to be changed.
+        /// </summary>
+        /// <remarks>
+        /// Call this before switching to a different WiFi network or restarting the event-based helper.
+        /// This method does not disconnect the WiFi adapter; call <see cref="Disconnect"/> first if needed.
+        /// </remarks>
+        public static void Reset()
+        {
+            // deregister event handler to prevent a handler leak
+            NetworkChange.NetworkAddressChanged -= AddressChangedCallback;
+
+            _helperInstanciated = false;
+            _ipAddressAvailable = null;
+            _networkReady = new(false);
+            _requiresDateTime = false;
+            _networkHelperStatus = NetworkHelperStatus.None;
+            _helperException = null;
+            _ipConfiguration = null;
+            _ssid = null;
+            _password = null;
+
+            // reset the underlying NetworkHelper as well
+            NetworkHelper.Reset();
         }
 
         private static bool ScanAndConnect(
@@ -494,15 +536,16 @@ namespace nanoFramework.Networking
         /// <summary>
         /// Perform setup of the various fields and events, along with any of the required event handlers.
         /// </summary>
-        /// <param name="setupEvents">Set true to setup the events. Required for the thread approach. Not required for the CancelationToken implementation.</param>
+        /// <param name="setupEvents">Set <see langword="true"/> to setup the events and background thread. Required for the event-based approach. Not required for the CancellationToken approach.</param>
         private static void SetupHelper(bool setupEvents)
         {
-            if (_helperInstanciated)
+            if (setupEvents)
             {
-                throw new InvalidOperationException();
-            }
-            else
-            {
+                if (_helperInstanciated)
+                {
+                    throw new InvalidOperationException();
+                }
+
                 // set flag
                 _helperInstanciated = true;
 
@@ -518,19 +561,16 @@ namespace nanoFramework.Networking
 
                 NetworkInterface[] nis = NetworkInterface.GetAllNetworkInterfaces();
 
-                if (setupEvents)
+                // check if there are any network interface setup
+                if (nis.Length == 0)
                 {
-                    // check if there are any network interface setup
-                    if (nis.Length == 0)
-                    {
-                        _networkHelperStatus = NetworkHelperStatus.FailedNoNetworkInterface;
+                    _networkHelperStatus = NetworkHelperStatus.FailedNoNetworkInterface;
 
-                        throw new NotSupportedException();
-                    }
-
-                    // setup handler
-                    NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler(AddressChangedCallback);
+                    throw new NotSupportedException();
                 }
+
+                // setup handler
+                NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler(AddressChangedCallback);
 
                 if (!string.IsNullOrEmpty(_ssid) &&
                     !string.IsNullOrEmpty(_password))
@@ -601,6 +641,18 @@ namespace nanoFramework.Networking
                 // update status
                 _networkHelperStatus = NetworkHelperStatus.Started;
             }
+            else
+            {
+                NetworkInterface[] nis = NetworkInterface.GetAllNetworkInterfaces();
+
+                NetworkHelperInternal.InternalSetupHelper(
+                    nis,
+                    _workingNetworkInterface,
+                    _ipConfiguration);
+
+                // update status
+                _networkHelperStatus = NetworkHelperStatus.Started;
+            }
         }
 
         private static void AddressChangedCallback(object sender, EventArgs e)
@@ -609,26 +661,39 @@ namespace nanoFramework.Networking
                 _workingNetworkInterface,
                 _ipConfiguration))
             {
-                _ipAddressAvailable.Set();
+                if (_ipAddressAvailable != null)
+                {
+                    _ipAddressAvailable.Set();
+                }
+
+                // re-signal ready; check DateTime condition in case it was required
+                if (!_requiresDateTime || DateTime.UtcNow.Year >= 2021)
+                {
+                    _networkReady.Set();
+                    _networkHelperStatus = NetworkHelperStatus.NetworkIsReady;
+                }
+            }
+            else
+            {
+                // IP was lost — reset signals so callers block until the connection is restored
+                _networkReady.Reset();
+
+                if (_ipAddressAvailable != null)
+                {
+                    _ipAddressAvailable.Reset();
+                }
+
+                _networkHelperStatus = NetworkHelperStatus.Reconnecting;
             }
         }
 
         /// <summary>
-        /// Method to reset internal fields to it's defaults
+        /// Method to reset internal fields to their defaults.
         /// ONLY TO BE USED BY UNIT TESTS
         /// </summary>
         internal static void ResetInstance()
         {
-            _ipAddressAvailable = null;
-            _networkReady = new(false);
-            _requiresDateTime = false;
-            _networkHelperStatus = NetworkHelperStatus.None;
-            _helperException = null;
-            _ipConfiguration = null;
-            _helperInstanciated = false;
-            _ssid = null;
-            _password = null;
-            NetworkHelper.ResetInstance();
+            Reset();
         }
     }
 }

--- a/System.Device.Wifi/Properties/AssemblyInfo.cs
+++ b/System.Device.Wifi/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.6.5")]
+[assembly: AssemblyNativeVersion("100.0.6.6")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Tests/NFUnitTestWifiConnection/ConnectToWifiFixIPAddressTests.cs
+++ b/Tests/NFUnitTestWifiConnection/ConnectToWifiFixIPAddressTests.cs
@@ -42,11 +42,11 @@ namespace NFUnitTestWifiConnection
 
             ConnectToWifiWithCredentialsTests.DisplayLastError(success);
 
-            Assert.True(success);
-            Assert.Null(WifiNetworkHelper.HelperException);
+            Assert.IsTrue(success);
+            Assert.IsNull(WifiNetworkHelper.HelperException);
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
 
         [TestMethod]
@@ -59,10 +59,10 @@ namespace NFUnitTestWifiConnection
                 new[] { "192.168.1.1" }), true);
 
             // wait 10 seconds to connect to the network
-            Assert.True(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
+            Assert.IsTrue(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
     }
 }

--- a/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsScanTests.cs
+++ b/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsScanTests.cs
@@ -38,11 +38,11 @@ namespace NFUnitTestWifiConnection
 
             ConnectToWifiWithCredentialsTests.DisplayLastError(success);
 
-            Assert.True(success);
-            Assert.Null(WifiNetworkHelper.HelperException);
+            Assert.IsTrue(success);
+            Assert.IsNull(WifiNetworkHelper.HelperException);
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
 
         [TestMethod]
@@ -54,11 +54,11 @@ namespace NFUnitTestWifiConnection
                 requiresDateTime: true);
 
             // wait 10 seconds to connect to the network and get an IP address
-            Assert.True(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
-            Assert.Null(WifiNetworkHelper.HelperException);
+            Assert.IsTrue(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
+            Assert.IsNull(WifiNetworkHelper.HelperException);
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
 
         [TestMethod]
@@ -67,16 +67,16 @@ namespace NFUnitTestWifiConnection
             WifiNetworkHelper.SetupNetworkHelper(true);
 
             // wait 10 seconds to connect to the network and get an IP address
-            Assert.True(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
+            Assert.IsTrue(WifiNetworkHelper.NetworkReady.WaitOne(10000, true));
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
 
         [TestMethod]
         public void TestSingleUsage()
         {
-            Assert.Throws(typeof(InvalidOperationException), () =>
+            Assert.ThrowsException(typeof(InvalidOperationException), () =>
             {
                 // call once, it's OK
                 WifiNetworkHelper.SetupNetworkHelper();

--- a/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsScanTests.cs
+++ b/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsScanTests.cs
@@ -84,6 +84,9 @@ namespace NFUnitTestWifiConnection
                 // call twice, it's a NO NO and should throw an exception
                 WifiNetworkHelper.SetupNetworkHelper();
             });
+
+            // clear static state so this test doesn't affect later tests
+            WifiNetworkHelper.Reset();
         }
     }
 }

--- a/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsTests.cs
+++ b/Tests/NFUnitTestWifiConnection/ConnectToWifiWithCredentialsTests.cs
@@ -54,11 +54,70 @@ namespace NFUnitTestWifiConnection
 
             DisplayLastError(success);
 
-            Assert.True(success);
-            Assert.Null(WifiNetworkHelper.HelperException);
+            Assert.IsTrue(success);
+            Assert.IsNull(WifiNetworkHelper.HelperException);
 
-            // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
+        }
+
+        [TestMethod]
+        public void TestRetryAfterTimeout()
+        {
+            // First attempt: very short timeout so it expires
+            CancellationTokenSource cs1 = new(1000);
+            var firstResult = WifiNetworkHelper.ConnectDhcp(
+                Ssid,
+                Password,
+                token: cs1.Token);
+
+            Assert.IsFalse(firstResult, "First call should have timed out");
+
+            // Second attempt with a longer timeout — must not throw InvalidOperationException
+            CancellationTokenSource cs2 = new(15000);
+            var secondResult = WifiNetworkHelper.ConnectDhcp(
+                Ssid,
+                Password,
+                requiresDateTime: true,
+                token: cs2.Token);
+
+            DisplayLastError(secondResult);
+            Assert.IsTrue(secondResult, "Second attempt should succeed after retry");
+
+            WifiNetworkHelper.Reset();
+        }
+
+        [TestMethod]
+        public void TestResetAllowsEventBasedRestart()
+        {
+            // Use event-based helper once
+            WifiNetworkHelper.SetupNetworkHelper(Ssid, Password);
+
+            bool connected = WifiNetworkHelper.NetworkReady.WaitOne(15000, true);
+            Assert.IsTrue(connected, "Expected to connect on first event-based attempt");
+
+            // Reset and restart with same credentials
+            WifiNetworkHelper.Reset();
+            WifiNetworkHelper.SetupNetworkHelper(Ssid, Password);
+
+            connected = WifiNetworkHelper.NetworkReady.WaitOne(15000, true);
+            Assert.IsTrue(connected, "Expected to connect after Reset + SetupNetworkHelper restart");
+
+            WifiNetworkHelper.Reset();
+        }
+
+        [TestMethod]
+        public void TestSingleUsageEventBased()
+        {
+            Assert.ThrowsException(typeof(System.InvalidOperationException), () =>
+            {
+                // First call is OK
+                WifiNetworkHelper.SetupNetworkHelper(Ssid, Password);
+
+                // Second call without Reset must throw
+                WifiNetworkHelper.SetupNetworkHelper(Ssid, Password);
+            });
+
+            WifiNetworkHelper.Reset();
         }
     }
 }

--- a/Tests/NFUnitTestWifiConnection/ConnectToWifiWithoutCredentialsTests.cs
+++ b/Tests/NFUnitTestWifiConnection/ConnectToWifiWithoutCredentialsTests.cs
@@ -30,11 +30,11 @@ namespace NFUnitTestWifiConnection
 
             ConnectToWifiWithCredentialsTests.DisplayLastError(success);
 
-            Assert.True(success);
-            Assert.Null(WifiNetworkHelper.HelperException);
+            Assert.IsTrue(success);
+            Assert.IsNull(WifiNetworkHelper.HelperException);
 
             // need to reset this internal flag to allow calling the NetworkHelper again
-            WifiNetworkHelper.ResetInstance();
+            WifiNetworkHelper.Reset();
         }
     }
 }


### PR DESCRIPTION
## Description
- Allow `WifiNetworkHelper` to be reset and started again.
- Keep reconnect state accurate when IP is lost and restored.
- Fix nanoFramework-nullability issue in the WiFi helper.
- Update WiFi tests to the v3 API.
- Refresh WiFi README guidance for retry/reconfiguration.

## Motivation and Context
- SetupNetworkHelper needed a supported way to stop, reconfigure, and start over.
- Reconnect paths should reflect real network loss/recovery instead of staying “ready”.
- Replacing deprecated assertion calls.
- Resolves nanoFramework/Home#1511

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
